### PR TITLE
fix: add stop links to transit routes

### DIFF
--- a/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/matsim/InfrastructureBuilder.java
+++ b/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/matsim/InfrastructureBuilder.java
@@ -69,10 +69,11 @@ class InfrastructureBuilder {
 
         // add first stop
         RouteStop firstRouteStop = (RouteStop) directedRouteElements.getFirst();
-        TransitStopFacility stopFacility = stopFacilities.get(firstRouteStop.getStopFacilityInfo().getId());
-        TransitRouteStop transitRouteStop = factory.createTransitRouteStop(stopFacility, OptionalTime.undefined(),
+        final TransitStopFacility[] stopFacility = {stopFacilities.get(firstRouteStop.getStopFacilityInfo().getId())};
+        TransitRouteStop transitRouteStop = factory.createTransitRouteStop(stopFacility[0], OptionalTime.undefined(),
                 OptionalTime.zeroSeconds());
         routeStops.add(transitRouteStop);
+        routeLinks.add(stopFacility[0].getLinkId());
 
         // loop over route elements, set first stop as last element and start with second element
         for (int i = 1; i < directedRouteElements.size(); i++) {
@@ -82,7 +83,6 @@ class InfrastructureBuilder {
 
             // visit element
             currentElement.accept(new RouteElementVisitor() {
-
 
                 @Override
                 public void visit(RouteStop routeStop) {
@@ -95,8 +95,8 @@ class InfrastructureBuilder {
                             travelTime[0] + dwellTime);
 
                     // add route stop
-                    TransitStopFacility stopFacility = stopFacilities.get(routeStop.getStopFacilityInfo().getId());
-                    TransitRouteStop transitRouteStop = factory.createTransitRouteStop(stopFacility, arrivalOffset,
+                    stopFacility[0] = stopFacilities.get(routeStop.getStopFacilityInfo().getId());
+                    TransitRouteStop transitRouteStop = factory.createTransitRouteStop(stopFacility[0], arrivalOffset,
                             departureOffset);
                     routeStops.add(transitRouteStop);
 
@@ -110,8 +110,9 @@ class InfrastructureBuilder {
 
             });
 
-            // connect stop facilities on network
+            // connect stop facilities on network and add stop link
             routeLinks.addAll(connect(stopFacilities, addedSegments, transitLineInfo, lastElement, currentElement));
+            routeLinks.add(stopFacility[0].getLinkId());
         }
 
         return factory.createTransitRoute(transitLine,


### PR DESCRIPTION
This pull request includes changes to the `InfrastructureBuilder.java` file to improve the handling of transit stop facilities and route links. The most important changes include the addition of stop links to the `routeLinks` list and the use of an array to store the current stop facility.

Improvements to transit stop handling:

* [`src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/matsim/InfrastructureBuilder.java`](diffhunk://#diff-919268b4c2ca685f924543e28b79271ab3ff1183c4fd9f5c4055f571e4a5b6ccL72-R76): Added stop links to the `routeLinks` list when adding the first stop and after visiting each route stop. [[1]](diffhunk://#diff-919268b4c2ca685f924543e28b79271ab3ff1183c4fd9f5c4055f571e4a5b6ccL72-R76) [[2]](diffhunk://#diff-919268b4c2ca685f924543e28b79271ab3ff1183c4fd9f5c4055f571e4a5b6ccL113-R115)
* [`src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/matsim/InfrastructureBuilder.java`](diffhunk://#diff-919268b4c2ca685f924543e28b79271ab3ff1183c4fd9f5c4055f571e4a5b6ccL72-R76): Used an array to store the current stop facility to ensure it can be updated within the loop. [[1]](diffhunk://#diff-919268b4c2ca685f924543e28b79271ab3ff1183c4fd9f5c4055f571e4a5b6ccL72-R76) [[2]](diffhunk://#diff-919268b4c2ca685f924543e28b79271ab3ff1183c4fd9f5c4055f571e4a5b6ccL98-R99)

Code cleanup:

* [`src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/matsim/InfrastructureBuilder.java`](diffhunk://#diff-919268b4c2ca685f924543e28b79271ab3ff1183c4fd9f5c4055f571e4a5b6ccL86): Removed unnecessary blank line in the `visit` method for `RouteElementVisitor`.