### PR TITLE
feat: add validation strategy REMOVE_DOTS_AND_REPLACE_WHITESPACE

### DIFF
--- a/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/validation/NetworkGraphicValidator.java
+++ b/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/validation/NetworkGraphicValidator.java
@@ -67,6 +67,12 @@ public class NetworkGraphicValidator {
         }
     }
 
+    void removeDotsReplaceWhitespace() {
+        log.info("Remove dots and replace whitespace in invalid IDs of network graphic");
+        networkGraphic = new NetworkGraphicSanitizer(networkGraphic, considerTrainruns,
+                ValidationUtils::removeDotsReplaceWhitespace).run();
+    }
+
     void replaceWhitespace() {
         log.info("Strip and replace whitespace in invalid IDs of network graphic");
         networkGraphic = new NetworkGraphicSanitizer(networkGraphic, considerTrainruns,

--- a/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/validation/ValidationStrategy.java
+++ b/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/validation/ValidationStrategy.java
@@ -45,6 +45,22 @@ public enum ValidationStrategy {
             }
             return true;
         }
+    },
+
+    /**
+     * @deprecated This option is deprecated because specialized treatment of the IDs should ideally be performed
+     * upstream of the converter. This option is provided only to ensure backward compatibility with the old default
+     * behavior. Users are encouraged to perform ID manipulations before invoking the converter, preferably directly in
+     * the Network Graphic Editor (NGE).
+     */
+    @Deprecated REMOVE_DOTS_AND_REPLACE_WHITESPACE {
+        @Override
+        public boolean apply(NetworkGraphicValidator validator) {
+            if (!validator.isValid()) {
+                validator.removeDotsReplaceWhitespace();
+            }
+            return true;
+        }
     };
 
     public abstract boolean apply(NetworkGraphicValidator validator);

--- a/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/validation/ValidationUtils.java
+++ b/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/validation/ValidationUtils.java
@@ -6,9 +6,11 @@ class ValidationUtils {
 
     private static final Pattern SPECIAL_CHAR_PATTERN = Pattern.compile("[^a-zA-Z0-9_\\-\\s]");
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
+    private static final Pattern DOT_PATTERN = Pattern.compile("\\.");
 
     private static final String SPECIAL_CHAR_REPLACEMENT = "";
     private static final String WHITESPACE_REPLACEMENT = "_";
+    private static final String DOT_REPLACEMENT = "";
 
     static boolean containsSpecialCharacter(String input) {
         return SPECIAL_CHAR_PATTERN.matcher(input).find();
@@ -20,6 +22,11 @@ class ValidationUtils {
 
     static boolean containsTrailingWhitespace(String input) {
         return !input.equals(input.strip());
+    }
+
+    static String removeDotsReplaceWhitespace(String input) {
+        return WHITESPACE_PATTERN.matcher(DOT_PATTERN.matcher(input).replaceAll(DOT_REPLACEMENT))
+                .replaceAll(WHITESPACE_REPLACEMENT);
     }
 
     static String removeSpecialCharacters(String input) {

--- a/src/test/java/ch/sbb/pfi/netzgrafikeditor/converter/core/validation/NetworkGraphicValidatorTest.java
+++ b/src/test/java/ch/sbb/pfi/netzgrafikeditor/converter/core/validation/NetworkGraphicValidatorTest.java
@@ -30,13 +30,13 @@ class NetworkGraphicValidatorTest {
                 Node.builder().betriebspunktName("in validNode").build(),
                 Node.builder().betriebspunktName(" invalidNode").build(),
                 Node.builder().betriebspunktName("invalidNode ").build(),
-                Node.builder().betriebspunktName("inVälidNöde").build());
+                Node.builder().betriebspunktName("inVälid.Nöde").build());
 
         List<Trainrun> trainruns = List.of(Trainrun.builder().name("validTrainrun").build(),
                 Trainrun.builder().name("in validTrainrun").build(),
                 Trainrun.builder().name(" invalidTrainrun").build(),
                 Trainrun.builder().name("invalidTrainrun ").build(),
-                Trainrun.builder().name("inVälidTräinrün").build());
+                Trainrun.builder().name("inVälid.Träinrün").build());
 
         original = NetworkGraphic.builder().nodes(nodes).trainruns(trainruns).build();
     }
@@ -54,10 +54,10 @@ class NetworkGraphicValidatorTest {
             case FAIL_ON_ISSUES -> assertThrows(IllegalStateException.class, validator::run);
             case REPLACE_WHITESPACE -> {
                 NetworkGraphic validated = validator.run();
-                assertEquals(List.of("validNode", "in_validNode", "invalidNode", "invalidNode", "inVälidNöde"),
+                assertEquals(List.of("validNode", "in_validNode", "invalidNode", "invalidNode", "inVälid.Nöde"),
                         getNodeIds(validated));
                 assertEquals(List.of("validTrainrun", "in_validTrainrun", "invalidTrainrun", "invalidTrainrun",
-                        "inVälidTräinrün"), getTrainrunIds(validated));
+                        "inVälid.Träinrün"), getTrainrunIds(validated));
             }
             case REMOVE_SPECIAL_CHARACTERS -> {
                 NetworkGraphic validated = validator.run();
@@ -66,7 +66,13 @@ class NetworkGraphicValidatorTest {
                 assertEquals(List.of("validTrainrun", "in_validTrainrun", "invalidTrainrun", "invalidTrainrun",
                         "inVlidTrinrn"), getTrainrunIds(validated));
             }
+            case REMOVE_DOTS_AND_REPLACE_WHITESPACE -> {
+                NetworkGraphic validated = validator.run();
+                assertEquals(List.of("validNode", "in_validNode", "_invalidNode", "invalidNode_", "inVälidNöde"),
+                        getNodeIds(validated));
+                assertEquals(List.of("validTrainrun", "in_validTrainrun", "_invalidTrainrun", "invalidTrainrun_",
+                        "inVälidTräinrün"), getTrainrunIds(validated));
+            }
         }
     }
-
 }


### PR DESCRIPTION
This option is deprecated because specialized treatment of the IDs should ideally be performed upstream of the converter. This option is provided only to ensure backward compatibility with the old default behavior. Users are encouraged to perform ID manipulations before invoking the converter, preferably directly in the Network Graphic Editor (NGE).