### PR TITLE
feat: exclude spring boot dependencies from maven lib build profile

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -9,8 +9,11 @@ on:
       - main
 
 jobs:
-  setup:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        profile: [ 'lib', 'app' ]
     steps:
       - uses: actions/checkout@v4
 
@@ -21,16 +24,5 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-  build-lib:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-      - name: Build lib
-        run: mvn -B verify --file pom.xml -P lib
-
-  build-app:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-      - name: Build app
-        run: mvn -B verify --file pom.xml -P app
+      - name: Build with Maven
+        run: mvn -B verify --file pom.xml -P ${{ matrix.profile }}

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -7,21 +7,30 @@ on:
   pull_request:
     branches:
       - main
-jobs:
-  build:
-    runs-on: ubuntu-latest
 
+jobs:
+  setup:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-      - name: Build with Maven
-        run: mvn -B verify --file pom.xml
 
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    # - name: Update dependency graph
-    #  uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+  build-lib:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Build lib
+        run: mvn -B verify --file pom.xml -P lib
+
+  build-app:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Build app
+        run: mvn -B verify --file pom.xml -P app

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -15,8 +16,9 @@
         day in different formats
     </description>
     <properties>
-        <matsim.version>2025.0-2024w51</matsim.version>
         <java.version>21</java.version>
+        <matsim.version>2025.0-2024w51</matsim.version>
+        <app.package>**/ch/sbb/pfi/netzgrafikeditor/converter/app/**</app.package>
     </properties>
 
     <distributionManagement>
@@ -90,6 +92,31 @@
                     </plugin>
                 </plugins>
             </build>
+            <dependencies>
+
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-actuator</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>info.picocli</groupId>
+                    <artifactId>picocli-spring-boot-starter</artifactId>
+                    <version>4.7.6</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-test</artifactId>
+                    <scope>test</scope>
+                </dependency>
+
+            </dependencies>
         </profile>
 
         <!-- build slim jar including javadoc and sources -->
@@ -106,8 +133,26 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.11.0</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>${app.package}</exclude>
+                            </excludes>
+                            <testExcludes>
+                                <testExclude>${app.package}</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.11.2</version>
+                        <configuration>
+                            <sourceFileExcludes>
+                                <sourceFileExclude>${app.package}</sourceFileExclude>
+                            </sourceFileExcludes>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -121,6 +166,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <version>3.3.1</version>
+                        <configuration>
+                            <excludes>${app.package}</excludes>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -132,6 +180,43 @@
                     </plugin>
                 </plugins>
             </build>
+            <dependencies>
+
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                    <version>2.0.16</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-engine</artifactId>
+                    <version>5.11.3</version>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-params</artifactId>
+                    <version>5.11.3</version>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                    <version>5.14.2</version>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-junit-jupiter</artifactId>
+                    <version>5.14.2</version>
+                    <scope>test</scope>
+                </dependency>
+
+            </dependencies>
         </profile>
     </profiles>
 
@@ -146,37 +231,14 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli-spring-boot-starter</artifactId>
-            <version>4.7.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.matsim</groupId>
             <artifactId>matsim</artifactId>
             <version>${matsim.version}</version>
-        </dependency>
-
-        <!-- test -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Description**

This pull request includes updates to the Maven build configuration and dependencies in the `pom.xml` file, as well as modifications to the GitHub Actions workflow for continuous integration:

- Remove spring boot dependencies from the lib profile.
- Run maven builds for both profiles in the CI.

**Checklist**

* [x] This PR contains a description of the changes I'm making and its title follows the Conventional Commit format (e.g., `feat:`, `fix:`)
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-converter/blob/main/CONTRIBUTING.md)
* [x] I've added tests for changes or features I've introduced
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review