### PR TITLE
feat(supply)!: introduce and enforce transport mode consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,24 +88,30 @@ public class Example {
                 customRollingStockRepository);
 
         // convert to GTFS
-        setupGtfsConverter(customInfrastructureRepository, customVehicleCircuitsPlanner, source).run();
+        setupGtfsConverter(customInfrastructureRepository, customRollingStockRepository, customVehicleCircuitsPlanner,
+                source).run();
 
         // convert to MATSim
-        setupMatsimConverter(customInfrastructureRepository, customVehicleCircuitsPlanner, source).run();
+        setupMatsimConverter(customInfrastructureRepository, customRollingStockRepository, customVehicleCircuitsPlanner,
+                source).run();
     }
 
-    private static NetworkGraphicConverter<Scenario> setupMatsimConverter(InfrastructureRepository customInfrastructureRepository, VehicleCircuitsPlanner customVehicleCircuitsPlanner, NetworkGraphicSource source) {
+    private static NetworkGraphicConverter<Scenario> setupMatsimConverter(
+            InfrastructureRepository customInfrastructureRepository, RollingStockRepository customRollingStockRepository,
+            VehicleCircuitsPlanner customVehicleCircuitsPlanner, NetworkGraphicSource source) {
         SupplyBuilder<Scenario> builder = new MatsimSupplyBuilder(customInfrastructureRepository,
-                customVehicleCircuitsPlanner);
+                customRollingStockRepository, customVehicleCircuitsPlanner);
         ConverterSink<Scenario> sink = new TransitScheduleXmlWriter(Example.OUTPUT_DIRECTORY, "");
 
         return new NetworkGraphicConverter<>(CONFIG, source, builder, sink);
     }
 
-    private static NetworkGraphicConverter<GtfsSchedule> setupGtfsConverter(InfrastructureRepository customInfrastructureRepository, VehicleCircuitsPlanner customVehicleCircuitsPlanner, NetworkGraphicSource source) {
+    private static NetworkGraphicConverter<GtfsSchedule> setupGtfsConverter(
+            InfrastructureRepository customInfrastructureRepository, RollingStockRepository customRollingStockRepository,
+            VehicleCircuitsPlanner customVehicleCircuitsPlanner, NetworkGraphicSource source) {
         SupplyBuilder<GtfsSchedule> builder = new GtfsSupplyBuilder(customInfrastructureRepository,
-                customVehicleCircuitsPlanner);
-        ConverterSink<GtfsSchedule> sink = new GtfsScheduleWriter(Example.OUTPUT_DIRECTORY);
+                customRollingStockRepository, customVehicleCircuitsPlanner);
+        ConverterSink<GtfsSchedule> sink = new GtfsScheduleWriter(Example.OUTPUT_DIRECTORY, true);
 
         return new NetworkGraphicConverter<>(CONFIG, source, builder, sink);
     }

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -15,7 +15,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <goals>

--- a/app/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/app/ConversionService.java
+++ b/app/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/app/ConversionService.java
@@ -51,7 +51,7 @@ public class ConversionService {
 
             case GTFS -> {
                 SupplyBuilder<GtfsSchedule> builder = new GtfsSupplyBuilder(infrastructureRepository,
-                        vehicleCircuitsPlanner);
+                        rollingStockRepository, vehicleCircuitsPlanner);
                 ConverterSink<GtfsSchedule> sink = new GtfsScheduleWriter(request.outputDirectory, true);
 
                 yield new NetworkGraphicConverter<>(request.converterConfig, source, builder, sink);
@@ -59,7 +59,7 @@ public class ConversionService {
 
             case MATSIM -> {
                 SupplyBuilder<Scenario> builder = new MatsimSupplyBuilder(infrastructureRepository,
-                        vehicleCircuitsPlanner);
+                        rollingStockRepository, vehicleCircuitsPlanner);
                 ConverterSink<Scenario> sink = new TransitScheduleXmlWriter(request.outputDirectory);
 
                 yield new NetworkGraphicConverter<>(request.converterConfig, source, builder, sink);

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.matsim</groupId>
             <artifactId>matsim</artifactId>
-            <version>2026.0-2025w23</version>
+            <version>2026.0-2025w25</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.matsim</groupId>
             <artifactId>matsim</artifactId>
-            <version>2026.0-2025w25</version>
+            <version>2026.0-2025w26</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.matsim</groupId>
             <artifactId>matsim</artifactId>
-            <version>2026.0-2025w22</version>
+            <version>2026.0-2025w23</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.matsim</groupId>
             <artifactId>matsim</artifactId>
-            <version>2026.0-2025w21</version>
+            <version>2026.0-2025w22</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/gtfs/GtfsSupplyBuilder.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/gtfs/GtfsSupplyBuilder.java
@@ -50,16 +50,6 @@ public class GtfsSupplyBuilder extends BaseSupplyBuilder<GtfsSchedule> {
         return stopFacilityInfo.getName().isEmpty() ? stopFacilityInfo.getId() : stopFacilityInfo.getName();
     }
 
-    @Override
-    protected void buildStopFacility(StopFacilityInfo stopFacilityInfo) {
-        stops.add(Stop.builder()
-                .stopId(stopFacilityInfo.getId())
-                .stopName(stopFacilityInfo.getName())
-                .stopLat(stopFacilityInfo.getCoordinate().getLatitude())
-                .stopLon(stopFacilityInfo.getCoordinate().getLongitude())
-                .build());
-    }
-
     private static RouteType toGtfsRouteType(TransportMode transportMode) {
         if (transportMode == null) {
             throw new IllegalArgumentException("Input TransportMode cannot be null.");
@@ -77,6 +67,16 @@ public class GtfsSupplyBuilder extends BaseSupplyBuilder<GtfsSchedule> {
             case TROLLEYBUS -> RouteType.TROLLEYBUS;
             case MONORAIL -> RouteType.MONORAIL;
         };
+    }
+
+    @Override
+    protected void buildStopFacility(StopFacilityInfo stopFacilityInfo) {
+        stops.add(Stop.builder()
+                .stopId(stopFacilityInfo.getId())
+                .stopName(stopFacilityInfo.getName())
+                .stopLat(stopFacilityInfo.getCoordinate().getLatitude())
+                .stopLon(stopFacilityInfo.getCoordinate().getLongitude())
+                .build());
     }
 
     @Override

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/gtfs/model/Route.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/gtfs/model/Route.java
@@ -15,6 +15,6 @@ public class Route {
 
     String routeLongName;
 
-    int routeType;
+    RouteType routeType;
 
 }

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/gtfs/model/RouteType.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/gtfs/model/RouteType.java
@@ -1,0 +1,38 @@
+package ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+/**
+ * Represents the GTFS route_type, indicating the mode of transport. The integer values and descriptions correspond to
+ * the official GTFS Static specification.
+ *
+ * @see <a href="https://gtfs.org/schedule/reference/#routestxt">GTFS route_type Documentation</a>
+ */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum RouteType {
+
+    TRAM(0),
+    SUBWAY(1),
+    RAIL(2),
+    BUS(3),
+    FERRY(4),
+    CABLE_TRAM(5),
+    AERIAL_LIFT(6),
+    FUNICULAR(7),
+    TROLLEYBUS(11),
+    MONORAIL(12);
+
+    private final int value;
+
+    public static RouteType fromValue(int value) {
+        return Arrays.stream(RouteType.values())
+                .filter(e -> e.getValue() == value)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown RouteType value: " + value));
+    }
+}

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/matsim/InfrastructureBuilder.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/matsim/InfrastructureBuilder.java
@@ -109,7 +109,8 @@ class InfrastructureBuilder {
             routeLinks.add(stopFacility[0].getLinkId());
         }
 
-        return factory.createTransitRoute(transitLine, transitRouteInfo.getId(), routeLinks, routeStops);
+        return factory.createTransitRoute(transitLine, transitRouteInfo.getId(),
+                transitRouteInfo.getTransitLineInfo().getTransportMode().name().toLowerCase(), routeLinks, routeStops);
     }
 
     // connects transit route stops on network, calls infrastructure repository for track information

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/matsim/MatsimSupplyBuilder.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/matsim/MatsimSupplyBuilder.java
@@ -3,6 +3,7 @@ package ch.sbb.pfi.netzgrafikeditor.converter.adapter.matsim;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.BaseSupplyBuilder;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.DepartureInfo;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.InfrastructureRepository;
+import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.RollingStockRepository;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.StopFacilityInfo;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.VehicleAllocation;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.VehicleCircuitsPlanner;
@@ -27,8 +28,8 @@ public class MatsimSupplyBuilder extends BaseSupplyBuilder<Scenario> {
     private final InfrastructureBuilder infrastructureBuilder;
     private final Scenario scenario;
 
-    public MatsimSupplyBuilder(InfrastructureRepository infrastructureRepository, VehicleCircuitsPlanner vehicleCircuitsPlanner) {
-        super(infrastructureRepository, vehicleCircuitsPlanner);
+    public MatsimSupplyBuilder(InfrastructureRepository infrastructureRepository, RollingStockRepository rollingStockRepository, VehicleCircuitsPlanner vehicleCircuitsPlanner) {
+        super(infrastructureRepository, rollingStockRepository, vehicleCircuitsPlanner);
         this.scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
         factory = new MatsimSupplyFactory(scenario);
         infrastructureBuilder = new InfrastructureBuilder(scenario, factory, infrastructureRepository);

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/matsim/MatsimSupplyFactory.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/matsim/MatsimSupplyFactory.java
@@ -61,7 +61,7 @@ class MatsimSupplyFactory {
         return sf.createDeparture(departureId, time);
     }
 
-    TransitRoute createTransitRoute(TransitLine transitLine, String id, List<Id<Link>> routeLinks, List<TransitRouteStop> stops) {
+    TransitRoute createTransitRoute(TransitLine transitLine, String id, String transportMode, List<Id<Link>> routeLinks, List<TransitRouteStop> stops) {
         Id<TransitRoute> routeId = Id.create(String.format(IdPattern.TRANSIT_ROUTE, id), TransitRoute.class);
         NetworkRoute networkRoute = RouteUtils.createNetworkRoute(routeLinks);
         TransitRoute transitRoute = transitLine.getRoutes().get(routeId);
@@ -73,6 +73,7 @@ class MatsimSupplyFactory {
 
         log.debug("Creating TransitRoute {} and adding to TransitLine {}", routeId, transitLine.getId());
         transitRoute = sf.createTransitRoute(routeId, networkRoute, stops, Default.NETWORK_MODE);
+        transitRoute.setTransportMode(transportMode);
         transitLine.addRoute(transitRoute);
 
         return transitRoute;

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/NetworkGraphicConverter.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/NetworkGraphicConverter.java
@@ -71,8 +71,14 @@ public class NetworkGraphicConverter<T> {
         log.info("Adding nodes of network graphic");
         for (Node node : lookup.nodes.values()) {
             log.debug("Adding node {}", node.getBetriebspunktName());
+
+            // The input coordinates originate from a graphical editor which uses a top-left origin system (Y-axis
+            // increases downwards). To transform these into a standard Cartesian or geographical coordinate system
+            // (bottom-left origin), the Y-coordinate must be inverted.
+            // Note: These transformed coordinates serve as a fallback. They are typically superseded by real-world
+            // coordinates from the infrastructure repository.
             builder.addStopFacility(node.getBetriebspunktName(), node.getFullName(), node.getPositionX(),
-                    node.getPositionY());
+                    -node.getPositionY());
         }
     }
 

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/TransitLineInfo.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/TransitLineInfo.java
@@ -2,10 +2,19 @@ package ch.sbb.pfi.netzgrafikeditor.converter.core.supply;
 
 import lombok.Value;
 
+
+/**
+ * Represents a group of routes publicly identified by a common name (e.g., "S1", "IC 5").
+ * <p>
+ * The {@link TransportMode} is defined at this level to ensure all associated routes share the same fundamental mode.
+ * For exceptions (e.g., a bus replacing a tram), model the replacement service as a separate, new
+ * {@code TransitLineInfo}.
+ */
 @Value
 public class TransitLineInfo {
 
     String id;
     String category;
+    TransportMode transportMode;
 
 }

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/TransitRouteInfo.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/TransitRouteInfo.java
@@ -2,6 +2,9 @@ package ch.sbb.pfi.netzgrafikeditor.converter.core.supply;
 
 import lombok.Value;
 
+/**
+ * A specific path or pattern of a {@link TransitLineInfo}, defined by a sequence of stops and passes.
+ */
 @Value
 public class TransitRouteInfo {
 

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/TransportMode.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/TransportMode.java
@@ -1,0 +1,17 @@
+package ch.sbb.pfi.netzgrafikeditor.converter.core.supply;
+
+/**
+ * Transport modes, aligned with the standard GTFS {@code route_type} specification.
+ */
+public enum TransportMode {
+    TRAM,
+    SUBWAY,
+    RAIL,
+    BUS,
+    FERRY,
+    CABLE_TRAM,
+    AERIAL_LIFT,
+    FUNICULAR,
+    TROLLEYBUS,
+    MONORAIL
+}

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/VehicleTypeInfo.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/VehicleTypeInfo.java
@@ -9,6 +9,7 @@ import java.util.Map;
 public class VehicleTypeInfo {
 
     String id;
+    TransportMode transportMode;
     int seats;
     int standingRoom;
     double length;

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/fallback/NoInfrastructureRepository.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/fallback/NoInfrastructureRepository.java
@@ -16,7 +16,7 @@ public class NoInfrastructureRepository implements InfrastructureRepository {
 
     @Override
     public StopFacilityInfo getStopFacility(String stopId, String stopName, double x, double y) {
-        Coordinate coordinate = new Coordinate(-y, x);
+        Coordinate coordinate = new Coordinate(y, x);
         coordinates.put(stopId, coordinate);
 
         return new StopFacilityInfo(stopId, stopName, coordinate);

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/fallback/NoRollingStockRepository.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/core/supply/fallback/NoRollingStockRepository.java
@@ -1,21 +1,30 @@
 package ch.sbb.pfi.netzgrafikeditor.converter.core.supply.fallback;
 
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.RollingStockRepository;
+import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.TransportMode;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.VehicleTypeInfo;
 
 import java.util.Map;
 
 public class NoRollingStockRepository implements RollingStockRepository {
 
+    public static final TransportMode DEFAULT_TRANSPORT_MODE = TransportMode.RAIL;
     public static final int DEFAULT_SEATS = 9999;
     public static final double DEFAULT_LENGTH = 100.; // meters
     public static final double DEFAULT_MAX_VELOCITY = 120 / 3.6; // meters per second
-    private static final int DEFAULT_STANDING_ROOM = 9999;
+    public static final int DEFAULT_STANDING_ROOM = 9999;
 
     @Override
     public VehicleTypeInfo getVehicleType(String category) {
-        return new VehicleTypeInfo(category, DEFAULT_SEATS, DEFAULT_STANDING_ROOM, DEFAULT_LENGTH, DEFAULT_MAX_VELOCITY,
-                Map.of());
+        TransportMode transportMode;
+        try {
+            transportMode = TransportMode.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            transportMode = DEFAULT_TRANSPORT_MODE;
+        }
+
+        return new VehicleTypeInfo(category, transportMode, DEFAULT_SEATS, DEFAULT_STANDING_ROOM, DEFAULT_LENGTH,
+                DEFAULT_MAX_VELOCITY, Map.of());
     }
 
 }

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/io/csv/CsvRollingStockRepository.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/io/csv/CsvRollingStockRepository.java
@@ -1,6 +1,7 @@
 package ch.sbb.pfi.netzgrafikeditor.converter.io.csv;
 
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.RollingStockRepository;
+import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.TransportMode;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.VehicleTypeInfo;
 import lombok.extern.slf4j.Slf4j;
 
@@ -16,6 +17,7 @@ public class CsvRollingStockRepository extends CsvRepository<VehicleTypeInfo> im
     public CsvRollingStockRepository(Path filePath) throws IOException {
         super(filePath, record -> {
             String category = record.get("category");
+            TransportMode transportMode = TransportMode.valueOf(record.get("transport_mode").toUpperCase());
             String vehicleTypeId = record.get("vehicle_type_id");
             int seats = Integer.parseInt(record.get("seats"));
             int standingRoom = Integer.parseInt(record.get("standing_room"));
@@ -23,7 +25,8 @@ public class CsvRollingStockRepository extends CsvRepository<VehicleTypeInfo> im
             double maxVelocity = Double.parseDouble(record.get("max_velocity")) / KMH_TO_MS;
 
             return new Entry<>(category,
-                    new VehicleTypeInfo(vehicleTypeId, seats, standingRoom, length, maxVelocity, new HashMap<>()));
+                    new VehicleTypeInfo(vehicleTypeId, transportMode, seats, standingRoom, length, maxVelocity,
+                            new HashMap<>()));
         });
     }
 

--- a/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/io/gtfs/GtfsScheduleWriter.java
+++ b/lib/src/main/java/ch/sbb/pfi/netzgrafikeditor/converter/io/gtfs/GtfsScheduleWriter.java
@@ -5,6 +5,7 @@ import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.Calendar;
 import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.FeedInfo;
 import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.GtfsSchedule;
 import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.Route;
+import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.RouteType;
 import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.Stop;
 import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.StopTime;
 import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.Trip;
@@ -91,6 +92,8 @@ public class GtfsScheduleWriter implements ConverterSink<GtfsSchedule> {
                     return casted.format(DATE_FORMATTER);
                 } else if (value instanceof Calendar.Type casted) {
                     return casted == Calendar.Type.AVAILABLE ? "1" : "0";
+                } else if (value instanceof RouteType casted) {
+                    return String.valueOf(casted.getValue());
                 } else if (value != null) {
                     return escapeCsv(value.toString());
                 } else {

--- a/lib/src/test/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/gtfs/GtfsSupplyBuilderTest.java
+++ b/lib/src/test/java/ch/sbb/pfi/netzgrafikeditor/converter/adapter/gtfs/GtfsSupplyBuilderTest.java
@@ -3,11 +3,15 @@ package ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs;
 import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.GtfsSchedule;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.DepartureInfo;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.InfrastructureRepository;
+import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.RollingStockRepository;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.StopFacilityInfo;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.TransitLineInfo;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.TransitRouteInfo;
+import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.TransportMode;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.VehicleAllocation;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.VehicleCircuitsPlanner;
+import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.VehicleInfo;
+import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.VehicleTypeInfo;
 import ch.sbb.pfi.netzgrafikeditor.converter.util.spatial.Coordinate;
 import ch.sbb.pfi.netzgrafikeditor.converter.util.time.ServiceDayTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -32,6 +37,9 @@ class GtfsSupplyBuilderTest {
 
     @Mock
     private InfrastructureRepository infrastructureRepository;
+
+    @Mock
+    private RollingStockRepository rollingStockRepository;
 
     @Mock
     private VehicleCircuitsPlanner vehicleCircuitsPlanner;
@@ -50,12 +58,16 @@ class GtfsSupplyBuilderTest {
         when(infrastructureRepository.getStopFacility(eq("d"), any(String.class), any(Double.class),
                 any(Double.class))).thenReturn(new StopFacilityInfo("d", "Stop D", new Coordinate(4, 4)));
 
-        TransitLineInfo transitLineInfo = new TransitLineInfo("lineId", null);
+        TransitLineInfo transitLineInfo = new TransitLineInfo("lineId", null, TransportMode.RAIL);
         TransitRouteInfo transitRouteInfo = new TransitRouteInfo("routeId", transitLineInfo);
         DepartureInfo departureInfo = new DepartureInfo(transitRouteInfo, ServiceDayTime.NOON);
-        VehicleAllocation vehicleAllocation = new VehicleAllocation(null, departureInfo, null);
+        VehicleTypeInfo vehicleTypeInfo = new VehicleTypeInfo("train", TransportMode.RAIL, 100, 150, 200, 90 * 3.6,
+                Map.of());
+        VehicleAllocation vehicleAllocation = new VehicleAllocation(null, departureInfo,
+                new VehicleInfo("train1", vehicleTypeInfo));
 
         when(vehicleCircuitsPlanner.plan()).thenReturn(List.of(vehicleAllocation));
+        when(rollingStockRepository.getVehicleType(any())).thenReturn(vehicleTypeInfo);
     }
 
     @Test
@@ -64,7 +76,7 @@ class GtfsSupplyBuilderTest {
                 .addStopFacility("b", "Stop B", 1, 0)
                 .addStopFacility("c", "Stop C", 2, 0)
                 .addStopFacility("d", "Stop D", 3, 0)
-                .addTransitLine("lineId", "IC")
+                .addTransitLine("lineId", "rail")
                 .addTransitRoute("routeId", "lineId", "a", Duration.of(5, ChronoUnit.MINUTES))
                 .addRoutePass("routeId", "b")
                 .addRouteStop("routeId", "c", Duration.of(10, ChronoUnit.MINUTES), Duration.of(5, ChronoUnit.MINUTES))

--- a/lib/src/test/java/ch/sbb/pfi/netzgrafikeditor/converter/core/NetworkGraphicConverterIT.java
+++ b/lib/src/test/java/ch/sbb/pfi/netzgrafikeditor/converter/core/NetworkGraphicConverterIT.java
@@ -4,6 +4,7 @@ import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.GtfsSupplyBuilder;
 import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.GtfsSchedule;
 import ch.sbb.pfi.netzgrafikeditor.converter.adapter.gtfs.model.StopTime;
 import ch.sbb.pfi.netzgrafikeditor.converter.adapter.matsim.MatsimSupplyBuilder;
+import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.RollingStockRepository;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.SupplyBuilder;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.fallback.NoInfrastructureRepository;
 import ch.sbb.pfi.netzgrafikeditor.converter.core.supply.fallback.NoRollingStockRepository;
@@ -104,8 +105,9 @@ public class NetworkGraphicConverterIT {
                     .build();
 
             NetworkGraphicSource source = new JsonFileReader(path);
+            RollingStockRepository rollingStockRepository = new NoRollingStockRepository();
             SupplyBuilder<Scenario> builder = new MatsimSupplyBuilder(new NoInfrastructureRepository(),
-                    new NoVehicleCircuitsPlanner(new NoRollingStockRepository()));
+                    rollingStockRepository, new NoVehicleCircuitsPlanner(rollingStockRepository));
 
             // store scenario and write schedule
             ConverterSink<Scenario> sink = result -> {
@@ -188,8 +190,9 @@ public class NetworkGraphicConverterIT {
                     .build();
 
             NetworkGraphicSource source = new JsonFileReader(path);
+            RollingStockRepository rollingStockRepository = new NoRollingStockRepository();
             SupplyBuilder<GtfsSchedule> builder = new GtfsSupplyBuilder(new NoInfrastructureRepository(),
-                    new NoVehicleCircuitsPlanner(new NoRollingStockRepository()));
+                    rollingStockRepository, new NoVehicleCircuitsPlanner(rollingStockRepository));
 
             // store and write schedule
             ConverterSink<GtfsSchedule> sink = result -> {

--- a/test/src/main/resources/ng/scenarios/realistic-rolling-stock-info.csv
+++ b/test/src/main/resources/ng/scenarios/realistic-rolling-stock-info.csv
@@ -1,3 +1,3 @@
-category,vehicle_type_id,seats,standing_room,length,max_velocity
-IC,FV-Dosto,600,0,200,200
-IR,IR-Dosto,350,550,100,160
+category,transport_mode,vehicle_type_id,seats,standing_room,length,max_velocity
+IC,rail,FV-Dosto,600,0,200,200
+IR,rail,IR-Dosto,350,550,100,160


### PR DESCRIPTION
## Transport Mode Consistency

**Description**

Refactors the supply building process to be aware of transport modes. The transport mode is now a first-class citizen in the domain model, derived from the line category and enforced throughout the conversion process.

- Introduces a `TransportMode` enum aligned with GTFS standards.
- The mode is stored on the `TransitLineInfo`, ensuring all routes on a line share the same mode.
- `BaseSupplyBuilder` now requires a `RollingStockRepository` to determine the transport mode when a transit line is created.
- Adds an atomic validation step in `BaseSupplyBuilder.build()` to ensure the `VehicleCircuitsPlanner` respects the line's transport mode, preventing inconsistent vehicle allocations.
- Adapters (GTFS, MATSim) are updated to correctly use the new transport mode information.
- Updates repository implementations and tests to support the new `TransportMode` field.

BREAKING CHANGE: The constructors for `BaseSupplyBuilder` (and all its subclasses like `GtfsSupplyBuilder` and `MatsimSupplyBuilder`) now require a `RollingStockRepository` instance. Any direct instantiation of these builders must be updated. Additionally, `VehicleTypeInfo` and `TransitLineInfo` constructors now require a `TransportMode` argument. The `CsvRollingStockRepository` now requires a `transport_mode` column in its input CSV file.

**Checklist**

* [x] This PR contains a description of the changes I'm making and its title follows the Conventional Commit format (
  e.g., `feat:`, `fix:`)
* [x] I've read
  the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-converter/blob/main/CONTRIBUTING.md)
* [x] I've added tests for changes or features I've introduced
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review