### PR TITLE
chore(deps): bump matsim and junit dependencies

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.matsim</groupId>
             <artifactId>matsim</artifactId>
-            <version>2026.0-2025w29</version>
+            <version>2026.0-2025w30</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>


### PR DESCRIPTION
Bumps the matsim version to 2026.0-2025w30 and incorporates related junit dependency updates from Dependabot.

These changes were bundled together as a single update. Merging the junit pull requests individually would have caused the CI pipeline to fail because the engine, params, and other components all need to be on the same version.

**Checklist**

* [x] This PR contains a description of the changes I'm making and its title follows the Conventional Commit format (
  e.g., `feat:`, `fix:`)
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-converter/blob/main/CONTRIBUTING.md)
* [x] I've added tests for changes or features I've introduced
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
